### PR TITLE
Update opdr_rechthoek.md

### DIFF
--- a/software/c++/oop-concepten/klassen/opdr_rechthoek.md
+++ b/software/c++/oop-concepten/klassen/opdr_rechthoek.md
@@ -45,7 +45,7 @@ Hieronder staat voorbeeldcode die misschien behulpzaam is.
 ```c++
 // incomplete code
 // exercise: draw a SFML rectangle
-#include "rectangle.hpp"
+#include <SFML/Graphics.hpp>
 #include <SFML/Window.hpp>
 #include <iostream>
 


### PR DESCRIPTION
De vorige implementatie gebruikte "rectangle.hpp". Dit is gecorrigeerd naar de juiste SFML-header <SFML/Graphics.hpp> voor grafische weergave.